### PR TITLE
fix: set up goreleaser and workflows properly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,5 +33,3 @@ jobs:
           distribution: goreleaser
           version: "~> v2"
           args: release --clean --snapshot
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release-tag:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          cache: false
+          go-version: "1.23"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,9 @@ builds:
     binary: gptscript-credential-sqlite
     env:
       - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
     goarch:
       - amd64
       - arm64
@@ -16,16 +19,14 @@ builds:
     ldflags:
       - -s
       - -w
-      - -X "github.com/gptscript-ai/gptscript/pkg/version.Tag=v{{ .Version }}"
 
 archives:
-  - id: default
+  # Disable archives, we just want the binaries
+  - id: no_archives
+    format: binary
+    name_template: "gptscript-credential-sqlite-{{ .Os }}-{{ .Arch }}"
     builds:
       - default
-    name_template: 'gptscript-credential-sqlite-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
-    format_overrides:
-      - goos: windows
-        format: zip
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
This sets up the CI and GoReleaser to create the binaries the way I need them to be named for GPTScript.